### PR TITLE
Add callable Dispatcher

### DIFF
--- a/lib/grand_central/dispatcher.rb
+++ b/lib/grand_central/dispatcher.rb
@@ -1,0 +1,27 @@
+module GrandCentral
+  module Dispatcher
+    def self.for store
+      Class.new do
+        define_method :initialize do |*args, &block|
+          if args.any? && block
+            fail ArgumentError,
+              "Cannot provide an action in both arguments and a block"
+          end
+
+          @store = store
+          @action = args.first || block
+        end
+
+        def call *args
+          action = if Proc === @action
+                     @action.call(*args)
+                   else
+                     @action
+                   end
+
+          @store.dispatch action
+        end
+      end
+    end
+  end
+end

--- a/spec/grand_central/dispatcher_spec.rb
+++ b/spec/grand_central/dispatcher_spec.rb
@@ -1,0 +1,42 @@
+require 'grand_central/dispatcher'
+require 'grand_central/store'
+require 'grand_central/action'
+
+module GrandCentral
+  describe Dispatcher do
+    let(:dispatch) { Dispatcher.for(store) }
+    let(:store) {
+      Store.new(0) do |state, action|
+        case action
+        when :increment then state + 1
+        when :decrement then state - 1
+        when action_class then action.value
+        else state
+        end
+      end
+    }
+    let(:action_class) { Action.with_attributes(:value) }
+
+    it 'forwards the action to the store' do
+      dispatch.new(:increment).call
+      expect(store.state).to eq 1
+
+      dispatch.new(:decrement).call
+      expect(store.state).to eq 0
+
+      dispatch.new(:foo).call
+      expect(store.state).to eq 0
+    end
+
+    it 'allows call to take arguments like DOM events' do
+      dispatch.new { |event| action_class.new(event) }.call(123)
+      expect(store.state).to eq 123
+    end
+
+    it 'cannot accept an action in both arguments and the block' do
+      expect {
+        dispatch.new(123) { 456 }
+      }.to raise_error(ArgumentError)
+    end
+  end
+end


### PR DESCRIPTION
I noticed in Clearwater apps I do this a lot:

``` ruby
div([
  button({ onclick: proc { store.dispatch A.new } }, 'A'),
  button({ onclick: proc { store.dispatch B.new } }, 'B'),
  button({ onclick: proc { store.dispatch C.new } }, 'C'),
])
```

This is a lot of repetition of `proc { |e| store.dispatch my_action }`. The only thing that differs between them is the action that gets dispatched. Since Clearwater allows any `call`-able object to handle UI events, I wanted to be able to simplify this to something like this:

``` ruby
div([
  button({ onclick: Dispatch.new(A.new) }, 'A'),
  button({ onclick: Dispatch.new(B.new) }, 'B'),
  button({ onclick: Dispatch.new(C.new) }, 'C'),
])
```

That way, we don't have to wrap the dispatch in a proc but we still delay it until the event occurs. For events that pass parameters, like input events, we could pass a block instead of an argument to the `Dispatch` constructor:

``` ruby
input(oninput: Dispatch.new { |e| A.new(e.target.value) }),
```

Now, as for how `Dispatch` knows how to direct it at the store we created (since stores are not singletons and we don't track store creation), we would set that up after our store is declared:

``` ruby
store = GrandCentral::Store.new(initial_state) do |state, action|
  # ...
end

Dispatch = GrandCentral::Dispatcher.new(store)
```

Then all dispatches triggered by `Dispatch` go to `store`.
