### PR TITLE
Add Model base class

### DIFF
--- a/lib/grand_central/model.rb
+++ b/lib/grand_central/model.rb
@@ -1,0 +1,29 @@
+module GrandCentral
+  class Model
+    def self.attributes *attrs
+      @attributes ||= Set.new
+      if attrs.any?
+        @attributes += attrs
+        attr_reader *attrs
+      end
+
+      @attributes
+    end
+
+    def initialize attributes={}
+      self.class.attributes.each do |attr|
+        instance_variable_set "@#{attr}", attributes[attr]
+      end
+    end
+
+    def update attributes={}
+      self.class.new(to_h.merge(attributes))
+    end
+
+    def to_h
+      self.class.attributes.each_with_object({}) do |attr, hash|
+        hash[attr] = send(attr)
+      end
+    end
+  end
+end

--- a/spec/grand_central/model_spec.rb
+++ b/spec/grand_central/model_spec.rb
@@ -1,0 +1,44 @@
+require 'grand_central/model'
+
+module GrandCentral
+  describe Model do
+    let(:model_class) {
+      Class.new(Model) do
+        attributes(
+          :foo,
+          :bar,
+          :baz,
+        )
+      end
+    }
+
+    describe :initialize do
+      it 'sets attributes' do
+        model = model_class.new(foo: 1, bar: 'two')
+
+        expect(model.foo).to eq 1
+        expect(model.bar).to eq 'two'
+        expect(model.baz).to be_nil
+      end
+    end
+
+    describe :update do
+      it 'returns a copy of the model with the updated attributes' do
+        model = model_class.new(foo: 1, bar: 'two')
+
+        new_model = model.update(foo: 2)
+
+        expect(new_model.foo).to eq 2
+        expect(new_model.bar).to eq 'two'
+      end
+
+      it 'does not mutate the model in place' do
+        model = model_class.new(foo: 1)
+
+        model.update foo: 2
+
+        expect(model.foo).to eq 1
+      end
+    end
+  end
+end


### PR DESCRIPTION
The idea here is to provide an immutable base class for your models. In nearly every app I've written that uses this gem, I've written some variation of this base class for my models.

And then I thought it might be useful if the _app state itself_ were a model:

```ruby
initial_state = AppState.new(
  todos: [
    Todo.new(
      description: 'Write pull request',
      complete: true,
    ),
  ],
)
```

Then, to update it, you would just call `update` on the model:

```ruby
store = GrandCentral::Store.new(initial_state) do |state, action|
  case action
  when AddTodo
    state.update(
      todos: state.todos + [action.todo]
    )
  end
end
```

This could help protect you from mistyping hash keys since you'd end up with a `NoMethodError` on your app state instead of on `nil` somewhere else in your app.

This base class could also pave the way for serializable models. If we also add some way to serialize subclasses of this class into JSON and reconstruct them, we could store app state in `localStorage`, transmit it to the server and store it in the database or some other persistent storage mechanism that lets the user pick up exactly where they left off next time the app is loaded.

So this PR isn't so much for the mechanics of a base class, but to work toward some more useful conventions. :-)