### PR TITLE
Add StoreMixin

### DIFF
--- a/lib/grand_central.rb
+++ b/lib/grand_central.rb
@@ -2,6 +2,7 @@ require "grand_central/version"
 require "grand_central/store"
 require "grand_central/action"
 require "grand_central/model"
+require "grand_central/store_mixin"
 
 module GrandCentral
 end

--- a/lib/grand_central/store_mixin.rb
+++ b/lib/grand_central/store_mixin.rb
@@ -1,0 +1,14 @@
+module GrandCentral
+  module StoreMixin
+    def self.for store
+      Module.new do
+        define_method(:state) { store.state }
+        define_method(:dispatch) { |action| store.dispatch action }
+
+        define_singleton_method :on_dispatch do |&block|
+          store.on_dispatch &block
+        end
+      end
+    end
+  end
+end

--- a/spec/grand_central/store_mixin_spec.rb
+++ b/spec/grand_central/store_mixin_spec.rb
@@ -1,0 +1,37 @@
+require 'grand_central/store'
+require 'grand_central/store_mixin'
+
+module GrandCentral
+  RSpec.describe StoreMixin do
+    # Store sets whatever is dispatched as the new state
+    let(:store) { GrandCentral::Store.new(nil) { |state, action| action } }
+
+    let(:mixin) { StoreMixin.for(store) }
+    let(:component_class) do
+      mixin = self.mixin
+      Class.new do
+        include mixin
+      end
+    end
+    let(:component) { component_class.new }
+
+    it 'adds state method to component' do
+      store.dispatch 12
+      expect(component.state).to eq 12
+    end
+
+    it 'adds dispatch method to component' do
+      component.dispatch 45
+      expect(component.state).to eq 45
+    end
+
+    it 'forwards on_dispatch handlers' do
+      x = 0
+      mixin.on_dispatch { x = 1 }
+
+      component.dispatch :omg
+
+      expect(x).to eq 1
+    end
+  end
+end


### PR DESCRIPTION
This PR lets you generate a mixin for a given store to include into your classes. For example, a Clearwater component can do something like this:

``` ruby
store = GrandCentral::Store.new(initial_state) { ... }
Store = GrandCentral::StoreMixin.for(store)
class MyComponent
  include Clearwater::Component
  include Store

  def render
    button({ onclick: proc { dispatch Clicked.new } }, 'Click me')
  end
end
```

In the above example, the render method wouldn't have access to thestore variable because class bodies and method definitions create an exclusive lexical scope. We would need a global constant we could access to include here.

You could also just assign your store to a constant, which is probably just as easy but ends up littering your component with that constant name. This cleans that up a bit.

This also closes #2 by making it obsolete.
