### PR TITLE
Allow GC Models to stand in for hashes via Mixin

### DIFF
--- a/lib/grand_central/model/subscriptable.rb
+++ b/lib/grand_central/model/subscriptable.rb
@@ -1,0 +1,16 @@
+require "grand_central/model"
+
+module GrandCentral
+  class Model
+    module Subscriptable
+      def self.included(base)
+        base.send(:alias_method, :merge, :update)
+      end
+
+      def [](attr)
+        send(attr)
+      end
+    end
+  end
+end
+

--- a/lib/grand_central/model/subscriptable.rb
+++ b/lib/grand_central/model/subscriptable.rb
@@ -3,8 +3,8 @@ require "grand_central/model"
 module GrandCentral
   class Model
     module Subscriptable
-      def self.included(base)
-        base.send(:alias_method, :merge, :update)
+      def merge(other)
+        update(other)
       end
 
       def [](attr)

--- a/spec/grand_central/model/subscriptable_spec.rb
+++ b/spec/grand_central/model/subscriptable_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+require "grand_central/model/subscriptable"
+
+module GrandCentral
+  class Model
+    describe Subscriptable do
+      let(:model_class) {
+        Class.new(Model) do
+          include Subscriptable
+          attributes :foo
+        end
+      }
+
+      it "allows attributes to be accessed via subscript operator" do
+        model = model_class.new(foo: 1)
+
+        expect(model[:foo]).to eq(1)
+      end
+
+      it "behaves a little hash-ier by aliasing update to merge" do
+        model = model_class.new(foo: 1)
+        new_model = model.merge(foo: "bar")
+
+        expect(new_model.foo).to eq("bar")
+      end
+    end
+  end
+end


### PR DESCRIPTION
My apps typically have bits of state that began as a hash, but evolve into a model. Requiring and including this module makes the transition easier.