### PR TITLE
Mixin methods are implemented on Store; store_mixin file doesn't exist

### DIFF
--- a/lib/grand_central.rb
+++ b/lib/grand_central.rb
@@ -2,7 +2,6 @@ require "grand_central/version"
 require "grand_central/store"
 require "grand_central/action"
 require "grand_central/model"
-require "grand_central/store_mixin"
 
 module GrandCentral
 end


### PR DESCRIPTION
Fixes #7 requiring nonexistent `store_mixin` file.