### PR TITLE
Add Elm-style action dispatching

### DIFF
--- a/lib/grand_central/action.rb
+++ b/lib/grand_central/action.rb
@@ -46,7 +46,7 @@ module GrandCentral
     end
 
     def self.[](*args)
-      Dispatcher.new(self, store, *args)
+      Dispatcher.new(self, store, args)
     end
 
     class Dispatcher

--- a/spec/grand_central/action_spec.rb
+++ b/spec/grand_central/action_spec.rb
@@ -1,4 +1,5 @@
 require 'grand_central/action'
+require 'grand_central/store'
 
 module GrandCentral
   describe Action do
@@ -60,6 +61,35 @@ module GrandCentral
       expect(then_called).to be_truthy
       expect(fail_called).to be_truthy
       expect(always_called).to be_truthy
+    end
+
+    it 'can dispatch to a store' do
+      action_class = Action.with_attributes(:foo, :bar)
+      store = Store.new(false) do |state, action|
+        case action
+        when action_class
+          [action.foo, action.bar]
+        else
+          raise "Action is not the expected action class"
+        end
+      end
+      action_class.store = store
+
+      expect(action_class)
+        .to receive(:new)
+        .with(1, 2)
+        .and_call_original
+
+      expect(store)
+        .to receive(:dispatch)
+        .and_call_original
+
+      action = action_class[1].call(2)
+
+      expect(action).to be_a action_class
+      expect(action.foo).to eq 1
+      expect(action.bar).to eq 2
+      expect(store.state).to eq [1, 2]
     end
   end
 end


### PR DESCRIPTION
Because three PRs open with different ideas to remove knowledge of a store from other things like Clearwater components (#2, #6, and #7) isn't enough, here's a fourth! This PR makes actions dispatchable by sending `call` to the class itself. Consider the following action:

```ruby
AddTodo = GrandCentral::Action.with_attributes(:name)
AddTodo.store = my_store
```

Then these two lines become equivalent:

```ruby
AddTodo.call 'test'
my_store.dispatch AddTodo.new('test')
```

In a Clearwater app, this gets really powerful:

```ruby
TodoList = Struct.new(:todos, :new_todo_text) do
  include Clearwater::Component

  def render
    form({ onsubmit: AddTodo[new_todo_text] }, [
      input(value: new_todo_text, oninput: SetText),
      # ...
    ])
  end
end
```

In this component, the action classes themselves handle their own dispatching. Notice we don't need to explicitly prevent the form submission or get the text input value from the `input` event. Both of these are handled for us. That's a little magic, but it does it in a way that keeps `grand_central` from depending on anything outside of itself. It's merely an optimization when it is used in this context.

The idea is that you're _probably_ using a single store for all actions you define for your app anyway, so this optimizes that particular setup. If you aren't using that setup, you'll just need to keep doing what you've been doing all along.

"But what about that `AddTodo[new_todo_text]`?", you may be asking. That, my friend, is a partially applied invocation (but in a more OO way — don't judge me). It means that if your action takes some arguments to its initializer that are known ahead of time and others that aren't known until you're ready to dispatch the action, you can specify the ones you _do_ know up front. Since we already know the text of the new todo, we can go ahead and apply that. This is great for the Clearwater use case because the action may be based on something passed into the component, but may also need information from a UI event.