### PR TITLE
Allow actions to be forked for testing

### DIFF
--- a/lib/grand_central/action.rb
+++ b/lib/grand_central/action.rb
@@ -7,6 +7,10 @@ module GrandCentral
           instance_variable_set "@#{attribute}", args[index]
         end
       end
+      define_singleton_method :fork do
+        with_attributes *attributes, &body
+      end
+
       klass.send :attr_reader, *attributes
       klass.class_exec &body if block_given?
 

--- a/spec/grand_central/action_spec.rb
+++ b/spec/grand_central/action_spec.rb
@@ -137,5 +137,17 @@ module GrandCentral
 
       expect(store.state).to eq [1, 2, 3]
     end
+
+    it 'can be forked into a new action with the same attributes' do
+      klass = Action.with_attributes(:foo, :bar)
+      forked = klass.fork
+
+      expect(forked).not_to be klass
+      expect(forked.superclass).to be klass
+
+      action = forked.new(1, 2)
+      expect(action.foo).to eq 1
+      expect(action.bar).to eq 2
+    end
   end
 end


### PR DESCRIPTION
This lets you fork an action in testing so you don't overwrite its
actual store for integration tests. Here is a simple example:

```ruby
Action = GrandCentral::Action.create
SetName = Action.with_attributes(:name)
AppState = GrandCentral::Model.with_attributes(:name)

initial_state = AppState.new(name: nil)
Store = GrandCentral::Store.new(initial_state) do |state, action|
  case action
  when SetName
    state.update name: action.name
  else state
  end
end

RSpec.describe SetName do
  let(:store) { Store.dup }
  let(:klass) { SetName.fork }
  before { klass.store = store }

  it 'sets the name' do
    klass.call 'My Name'

    expect(store.state.name).to eq 'My Name'
  end
end
```

Since the fork will still match in a `case` statement, it