### PR TITLE
Keyword actions

### DIFF
--- a/lib/grand_central/action.rb
+++ b/lib/grand_central/action.rb
@@ -17,6 +17,16 @@ module GrandCentral
       with_attributes &block
     end
 
+    def self.with_keyword_attributes *attributes, &body
+      Class.new(with_attributes *attributes, &body).tap do |klass|
+        klass.send :define_method, :initialize do |**values|
+          attributes.each do |attr|
+            instance_variable_set "@#{attr}", values[attr]
+          end
+        end
+      end
+    end
+
     def then &block
       promise.then &block
     end

--- a/lib/grand_central/action.rb
+++ b/lib/grand_central/action.rb
@@ -3,8 +3,23 @@ module GrandCentral
     def self.with_attributes *attributes, &body
       klass = Class.new(self)
       klass.send :define_method, :initialize do |*args|
-        attributes.each_with_index do |attribute, index|
-          instance_variable_set "@#{attribute}", args[index]
+        case args.first
+        when Hash
+          hash = args.first
+
+          if attributes.all? { |key| hash.include? key }
+            attributes.each do |attr|
+              instance_variable_set "@#{attr}", hash[attr]
+            end
+          else
+            attributes.each_with_index do |attribute, index|
+              instance_variable_set "@#{attribute}", args[index]
+            end
+          end
+        else
+          attributes.each_with_index do |attribute, index|
+            instance_variable_set "@#{attribute}", args[index]
+          end
         end
       end
       klass.send :attr_reader, *attributes

--- a/spec/grand_central/action_spec.rb
+++ b/spec/grand_central/action_spec.rb
@@ -137,5 +137,13 @@ module GrandCentral
 
       expect(store.state).to eq [1, 2, 3]
     end
+
+    it 'can accept keyword attributes' do
+      klass = Action.with_keyword_attributes(:foo, :bar)
+      action = klass.new(foo: 1, bar: 2)
+
+      expect(action.foo).to eq 1
+      expect(action.bar).to eq 2
+    end
   end
 end


### PR DESCRIPTION
This PR adds two possibilities for allowing attributes to be specified with keyword args. One adds a separate `Action.with_keyword_attributes` method and the other determines keyword-ness dynamically during instantiation.

```ruby
# Can be used as either keyword *or* positional with the same class
CombinedAction = Action.with_attributes(:foo, :bar)
keyword_action = CombinedAction.new(foo: 1, bar: 2)
positional_action = CombinedAction.new(1, 2)

# Only allows keyword arguments
KeywordOnlyAction = Action.with_keyword_attributes(:foo, :bar)
keyword_only_action = KeywordOnlyAction.new(foo: 1, bar: 2)
```

For the record, I don't think they should _both_ be added, but I think we should choose one based on the following criteria:

- Is it confusing if we allow both positional and keyword attributes with the same declaration?
- Is it slower to determine whether to use keywords?
- How fallible is the keyword/positional distinction in reality?
  - Specifically, I'm thinking of client-side uses here rather than server-side
  - Method arity in dynamically generated methods in Opal isn't always spot-on. I don't know if that's Opal's fault, tbh — it could just be an artifact of it being ambiguous whether to `call` or `apply` functions in JS based on the Ruby source.

The separate declaration method is _simpler_ in a micro sense, but is yet another thing to remember. I'd been thinking of deprecating `with_attributes` entirely and just using `create` for both to _remove_ distinctions like this, so I'm not super keen on adding another method if we don't need to. But if it clarifies things I'd much rather do that than mess with a bunch of magic.